### PR TITLE
Feat: 웹뷰 통신 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import TodoList from "./components/TodoList";
 import { Tag, TagList } from "./components/TagList";
 import { DateRangePicker } from "react-date-range";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { hipTag } from "./constants/tag";
 import todosWithTagsAndDate from "./recoil/todosWithTagsAndDate";
 import { useRecoilValue } from "recoil";
@@ -12,8 +12,11 @@ import "react-date-range/dist/theme/default.css";
 import { Logo } from "./assets/svg";
 import { dateToServerString } from "./utils/date";
 import React from "react";
+import fromFlutter from "./utils/fromFlutter";
+import useReFreshTodo from "./hooks/useRefreshTodo";
 
 function App() {
+  const refresh = useReFreshTodo();
   const [tags, setTags] = useState(
     hipTag.map((tags) => ({
       ...tags,
@@ -44,6 +47,13 @@ function App() {
       )
     );
   };
+
+  useEffect(() => {
+    window.fromFlutter = async (message) => {
+      await fromFlutter(message);
+      await (async () => refresh())();
+    };
+  }, []);
 
   return (
     <Wrapper>

--- a/src/constants/tag.js
+++ b/src/constants/tag.js
@@ -20,7 +20,7 @@ export const hipTag = [
     localeName: "BE",
   },
   {
-    name: "modile",
+    name: "mobile",
     localeName: "모바일",
   },
 ];

--- a/src/dto/fromFlutterMessage.js
+++ b/src/dto/fromFlutterMessage.js
@@ -1,0 +1,23 @@
+const MESSAGETYPE_CREATE_TODO = "createTodo";
+const MESSAGETYPE_EDIT_TODO = "editTodo";
+
+const createMessageDto = {
+  type: MESSAGETYPE_CREATE_TODO,
+  data: {
+    title: "",
+    content: "",
+    tag: "",
+  },
+};
+
+const editMessageDto = {
+  type: MESSAGETYPE_EDIT_TODO,
+  data: {
+    id: 0,
+    title: "",
+    content: "",
+    tag: "",
+  },
+};
+
+export { createMessageDto, editMessageDto };

--- a/src/hooks/useRefreshTodo.js
+++ b/src/hooks/useRefreshTodo.js
@@ -1,0 +1,7 @@
+import { useRecoilRefresher_UNSTABLE } from "recoil";
+import todoListAtom from "../recoil/todoListAtom";
+
+export default function useReFreshTodo() {
+  const refresh = useRecoilRefresher_UNSTABLE(todoListAtom);
+  return refresh;
+}

--- a/src/utils/fromFlutter.js
+++ b/src/utils/fromFlutter.js
@@ -1,0 +1,18 @@
+import { createTodo, editTodo } from "../apis/todo";
+import { createMessageDto, editMessageDto } from "../dto/fromFlutterMessage";
+
+async function fromFlutter(message) {
+  const { type = "", data = {} } = message;
+  switch (type) {
+    case "createTodo":
+      const createTodoData = { ...createMessageDto, type, data };
+      return await createTodo(createTodoData.data);
+    case "editTodo":
+      const editTodoData = { ...editMessageDto, type, data };
+      return await editTodo(editTodoData.data);
+    default:
+      throw new Error(`메세지 타입을 확인해주세요 : ${type}`);
+  }
+}
+
+export default fromFlutter;


### PR DESCRIPTION
## 플러터에서 보내주는 데이터 웹뷰에서 수신하는 기능 구현. 

- 전역 프로퍼티 window.fromFlutter에, 웹뷰에서 보내주는 데이터 수신하는 코드 작성
   - app.js의 useEffect에서 등록합니다
   - 데이터 수신 이후 createTodo api 요청하는 코드는 utils/fromFlutter입니다
   - createTodo 요청 이후, recoil의 useRecoilRefresher 코드로 서버 에서 todo 데이터를 재요청합니다.

<br>